### PR TITLE
Fixed Pytest (simple API changes only)

### DIFF
--- a/tests/test_Experiment.py
+++ b/tests/test_Experiment.py
@@ -1,12 +1,12 @@
 import pytest
 from pyplate.experiment_design import Factor, Experiment, ExperimentalSpace
-from pyplate.pyplate import Container
+from pyplate.pyplate import Container, Substance
 
 
 @pytest.fixture
 def example_experiment():
     factors = {"Factor1": "Value1", "Factor2": "Value2"}
-    return Experiment(factors, 1, 0)
+    return Experiment(factors, 1, 0, verifier=lambda x: True)
 
 
 # Tests for the Experiment class
@@ -18,7 +18,7 @@ def test_experiment_creation(example_experiment):
 
 def test_experiment_mapping_well(example_experiment):
     well = Container("96-well")
-    example_experiment.map_well(well)
+    example_experiment.map_container(well)
     assert example_experiment.well == well
 
 
@@ -28,7 +28,14 @@ def test_experiment_repr(example_experiment):
 
 
 def test_experiment_str(example_experiment):
-    expected_str = "Experiment: {'Factor1': 'Value1', 'Factor2': 'Value2'} with experiment_id 1 and replicate_idx 0"
+    water = Substance("H2O", mol_type=2)
+    water.mol_weight = 18.0153
+    water.density = 1
+    well = Container(
+        "96-well", max_volume="7.77 L", initial_contents=[(water, "7.76 L")]
+    )
+    example_experiment.map_container(well)
+    expected_str = "Experiment: {'Factor1': 'Value1', 'Factor2': 'Value2'} with experiment_id 1, replicate_idx 0, mapped to well Container (96-well) (7760.0/7770.0 mL of (['H2O (LIQUID): 430.745 mol'])"
     assert str(example_experiment) == expected_str
 
 

--- a/tests/test_ExperimentalSpace.py
+++ b/tests/test_ExperimentalSpace.py
@@ -88,260 +88,37 @@ def test_experimental_space_add_experiment_verification(
 
 
 def test_experimental_space_generate_experiments(cookie_experimental_space):
-    expected_exps = {
-        (300, "Chocolate Chip"): [
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 300,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 300,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                2,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 300,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 300,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                2,
-                None,
-            ),
-        ],
-        (300, "Oatmeal Raisin"): [
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 300,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 300,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                2,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 300,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 300,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                2,
-                None,
-            ),
-        ],
-        (300, "Peanut Butter"): [
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 300,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 300,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                2,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 300,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 300,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                2,
-                None,
-            ),
-        ],
-        (350, "Chocolate Chip"): [
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 350,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 350,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                2,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 350,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 350,
-                    "Flavor": "Chocolate Chip",
-                },
-                1,
-                2,
-                None,
-            ),
-        ],
-        (350, "Oatmeal Raisin"): [
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 350,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 350,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                2,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 350,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 350,
-                    "Flavor": "Oatmeal Raisin",
-                },
-                1,
-                2,
-                None,
-            ),
-        ],
-        (350, "Peanut Butter"): [
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 350,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 10,
-                    "Baking Temperature": 350,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                2,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 350,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                1,
-                None,
-            ),
-            Experiment(
-                {
-                    "Baking Time": 30,
-                    "Baking Temperature": 350,
-                    "Flavor": "Peanut Butter",
-                },
-                1,
-                2,
-                None,
-            ),
-        ],
-    }
+    expected_exps = \
+        {(300, 'Chocolate Chip'): [
+            Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
+            Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 2, None),
+            Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
+            Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 2, None)],
+         (300, 'Oatmeal Raisin'): [
+             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
+             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None)],
+         (300, 'Peanut Butter'): [
+             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 1, None),
+             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 2, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 1, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 2, None)],
+         (350, 'Chocolate Chip'): [
+             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
+             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 2, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 2, None)],
+         (350, 'Oatmeal Raisin'): [
+             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
+             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None)],
+         (350, 'Peanut Butter'): [
+             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 1, None),
+             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 2, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 1, None),
+             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 2, None)]}
 
     generated_exps = cookie_experimental_space.generate_experiments(
         factors={

--- a/tests/test_ExperimentalSpace.py
+++ b/tests/test_ExperimentalSpace.py
@@ -6,101 +6,352 @@ import collections
 
 @pytest.fixture
 def example_factor():
-    return Factor("ExampleFactor", ["Value1", "Value2"], lambda x, y: True)
+    return Factor("ExampleFactor", ["Value1", "Value2"])
 
 
 @pytest.fixture
 def another_factor():
-    return Factor("AnotherFactor", ["ValueA", "ValueB"], lambda x, y: True)
+    return Factor("AnotherFactor", ["ValueA", "ValueB"])
 
 
 @pytest.fixture
 def example_experiment(example_factor):
     factors = {"ExampleFactor": "Value1"}
-    return Experiment(factors, 1, 0)
+    return Experiment(factors, 1, 0, verifier=lambda: True)
 
 
 @pytest.fixture
 def example_experimental_space(example_factor):
-    return ExperimentalSpace(set(), lambda: 1)
+    return ExperimentalSpace(set(), lambda: 1, factor_rules=lambda: True)
 
 
 @pytest.fixture
 def cookie_experimental_space():
-    f1 = Factor(name="Baking Time", possible_values=[10, 20, 30], verifier=lambda: True)
-    f2 = Factor(name="Baking Temperature", possible_values=[300, 350, 400], verifier=lambda: True)
-    f3 = Factor(name="Flavor", possible_values=["Chocolate Chip", "Oatmeal Raisin", "Peanut Butter"],
-                verifier=lambda: True)
+    f1 = Factor(name="Baking Time", possible_values=[10, 20, 30])
+    f2 = Factor(name="Baking Temperature", possible_values=[300, 350, 400])
+    f3 = Factor(
+        name="Flavor",
+        possible_values=["Chocolate Chip", "Oatmeal Raisin", "Peanut Butter"],
+    )
 
-    return ExperimentalSpace(factors={f1, f2, f3}, experiment_id_generator=lambda: 1)
+    return ExperimentalSpace(
+        factors={f1, f2, f3},
+        experiment_id_generator=lambda: 1,
+        factor_rules=lambda: True,
+    )
 
 
 # Tests for the ExperimentalSpace class
-def test_experimental_space_register_factor_verification(example_experimental_space, example_factor):
+def test_experimental_space_register_factor_verification(
+    example_experimental_space, example_factor
+):
     example_experimental_space.register_factor(example_factor)
 
     # Verify that registering a factor with the same name raises ValueError
-    with pytest.raises(Exception, match=f"Factor {example_factor.name} already exists in experimental space"):
+    with pytest.raises(
+        Exception,
+        match=f"Factor {example_factor.name} already exists in experimental space",
+    ):
         example_experimental_space.register_factor(example_factor)
 
 
-def test_experimental_space_add_experiment_verification(example_experimental_space, example_experiment, another_factor):
+def test_experimental_space_add_experiment_verification(
+    example_experimental_space, example_experiment, another_factor
+):
     example_experimental_space.register_factor(another_factor)
 
     # Verify that adding an experiment with factors not matching experimental space factors raises ValueError
-    invalid_experiment = Experiment({"InvalidFactor": "Value1"}, 2, 0)
-    with pytest.raises(ValueError, match=re.escape(f"Experiment factors {invalid_experiment.factors.keys()} "
-                                                   f"do not match experimental space factors {example_experimental_space.factors}")):
+    invalid_experiment = Experiment(
+        {"InvalidFactor": "Value1"}, 2, 0, verifier=lambda: True
+    )
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            f"Experiment factors {invalid_experiment.factors.keys()} "
+            f"do not match experimental space factors {example_experimental_space.factors}"
+        ),
+    ):
         example_experimental_space.add_experiment(invalid_experiment)
 
     # Verify that adding an experiment with a factor value not in possible values raises ValueError
-    invalid_experiment = Experiment({"AnotherFactor": "InvalidValue"}, 3, 0)
-    with pytest.raises(ValueError, match=re.escape("Experiment factor AnotherFactor value InvalidValue "
-                                                   f"not in possible values ['ValueA', 'ValueB']")):
+    invalid_experiment = Experiment(
+        {"AnotherFactor": "InvalidValue"}, 3, 0, verifier=lambda: True
+    )
+    with pytest.raises(
+        ValueError,
+        match=re.escape(
+            "Experiment factor AnotherFactor value InvalidValue "
+            f"not in possible values ['ValueA', 'ValueB']"
+        ),
+    ):
         example_experimental_space.add_experiment(invalid_experiment)
 
 
 def test_experimental_space_generate_experiments(cookie_experimental_space):
-    expected_exps = \
-        {(300, 'Chocolate Chip'): [
-            Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
-            Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 2, None),
-            Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
-            Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Chocolate Chip'}, 1, 2, None)],
-         (300, 'Oatmeal Raisin'): [
-             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
-             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None)],
-         (300, 'Peanut Butter'): [
-             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 1, None),
-             Experiment({'Baking Time': 10, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 2, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 1, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 300, 'Flavor': 'Peanut Butter'}, 1, 2, None)],
-         (350, 'Chocolate Chip'): [
-             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
-             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 2, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 1, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Chocolate Chip'}, 1, 2, None)],
-         (350, 'Oatmeal Raisin'): [
-             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
-             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 1, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Oatmeal Raisin'}, 1, 2, None)],
-         (350, 'Peanut Butter'): [
-             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 1, None),
-             Experiment({'Baking Time': 10, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 2, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 1, None),
-             Experiment({'Baking Time': 30, 'Baking Temperature': 350, 'Flavor': 'Peanut Butter'}, 1, 2, None)]}
+    expected_exps = {
+        (300, "Chocolate Chip"): [
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 300,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 300,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                2,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 300,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 300,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                2,
+                None,
+            ),
+        ],
+        (300, "Oatmeal Raisin"): [
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 300,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 300,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                2,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 300,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 300,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                2,
+                None,
+            ),
+        ],
+        (300, "Peanut Butter"): [
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 300,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 300,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                2,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 300,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 300,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                2,
+                None,
+            ),
+        ],
+        (350, "Chocolate Chip"): [
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 350,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 350,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                2,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 350,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 350,
+                    "Flavor": "Chocolate Chip",
+                },
+                1,
+                2,
+                None,
+            ),
+        ],
+        (350, "Oatmeal Raisin"): [
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 350,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 350,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                2,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 350,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 350,
+                    "Flavor": "Oatmeal Raisin",
+                },
+                1,
+                2,
+                None,
+            ),
+        ],
+        (350, "Peanut Butter"): [
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 350,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 10,
+                    "Baking Temperature": 350,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                2,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 350,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                1,
+                None,
+            ),
+            Experiment(
+                {
+                    "Baking Time": 30,
+                    "Baking Temperature": 350,
+                    "Flavor": "Peanut Butter",
+                },
+                1,
+                2,
+                None,
+            ),
+        ],
+    }
 
     generated_exps = cookie_experimental_space.generate_experiments(
         factors={
             "Baking Time": [10, 30],
             "Baking Temperature": [300, 350],
-            "Flavor": "all"
+            "Flavor": "all",
         },
         n_replicates=2,
-        blocking_factors=["Baking Temperature", "Flavor"]
+        blocking_factors=["Baking Temperature", "Flavor"],
+        experiment_verifier=lambda: True,
     )
 
     assert generated_exps == expected_exps

--- a/tests/test_Factor.py
+++ b/tests/test_Factor.py
@@ -2,13 +2,9 @@ import pytest
 from pyplate.experiment_design import Factor
 
 
-def dummy_verifier():
-    return True
-
-
 @pytest.fixture
 def example_factor():
-    return Factor("ExampleFactor", ["Value1", "Value2"], dummy_verifier)
+    return Factor("ExampleFactor", ["Value1", "Value2"])
 
 
 def test_factor_creation(example_factor):
@@ -17,12 +13,15 @@ def test_factor_creation(example_factor):
 
 
 def test_factor_representation(example_factor):
-    assert str(example_factor) == "Factor: ExampleFactor with possible values ['Value1', 'Value2']"
+    assert (
+        str(example_factor)
+        == "Factor: ExampleFactor with possible values ['Value1', 'Value2']"
+    )
 
 
 def test_factor_equality(example_factor):
     # Create a copy of the example_factor
-    copied_factor = Factor("ExampleFactor", ["Value1", "Value2"], dummy_verifier)
+    copied_factor = Factor("ExampleFactor", ["Value1", "Value2"])
 
     # Check that the __eq__ method correctly identifies the factors as equal
     assert example_factor == copied_factor

--- a/tests/test_recipe_amount_used.py
+++ b/tests/test_recipe_amount_used.py
@@ -59,7 +59,7 @@ def test_recipe_tracking_before(water):
 
     print(step.frm)
     print(step.to)
-    assert recipe.substance_used(substance=water, unit='mL', destinations=[container]) == 5.0
+    assert recipe.get_substance_used(substance=water, unit='mL', destinations=[container]) == 5.0
 
 
 def test_container_to_plate(triethylamine, empty_plate):
@@ -138,7 +138,7 @@ def test_container_to_plate(triethylamine, empty_plate):
 
     # assert (np.full((8, 12), expected_volume_container) == plate.volumes(unit='uL')).all()
     # 100 muL is transferred to 96 wells in the plate, hence total expected value is 9600
-    assert pytest.approx(recipe.substance_used(substance=triethylamine, timeframe='transfer_stage', unit='uL',
+    assert pytest.approx(recipe.get_substance_used(substance=triethylamine, timeframe='transfer_stage', unit='uL',
                                                destinations=[empty_plate])) == 9600.0
     # assert pytest.approx(
     #     recipe.get_substance_used(substance=triethylamine, timeframe='dispensing', unit='uL')) == expected_volume_plate
@@ -194,7 +194,7 @@ def test_substance_used_dilute(salt, water):
     # Results would contain the pointers to the new containers, so assert from there
 
     expected_salt_amount = 5.0
-    assert recipe.substance_used(substance=salt, destinations=[container], timeframe='dilution_stage',
+    assert recipe.get_substance_used(substance=salt, destinations=[container], timeframe='dilution_stage',
                                  unit='mmol') == expected_salt_amount
 
 
@@ -240,7 +240,7 @@ def test_substance_used_create_solution(salt, water):
     # Container starts with 100 mmol of salt. 1 mmol is dispensed to each of 96 wells in the plate.
     # A net of 4 mmol is "used" into the container
     expected_salt_amount = 4.0
-    assert recipe.substance_used(substance=salt, unit='mmol', destinations=[container],
+    assert recipe.get_substance_used(substance=salt, unit='mmol', destinations=[container],
                                  timeframe='stage1') == expected_salt_amount
 
 
@@ -293,9 +293,9 @@ def test_substance_used_create_solution_from(salt, water, triethylamine):
     expected_salt_amount_stage2 = 0.0
     # If destination for stage2 was new_container, then expected_salt_amount_stage2 would be 10.0
 
-    assert recipe.substance_used(substance=salt, timeframe='stage1', unit='mmol', destinations=[container,
+    assert recipe.get_substance_used(substance=salt, timeframe='stage1', unit='mmol', destinations=[container,
                                                                                                 new_container]) == expected_salt_amount_stage1, "The reported amount of salt used does not match the expected value."
-    assert recipe.substance_used(substance=salt, timeframe='stage2', unit='mmol', destinations=[container,
+    assert recipe.get_substance_used(substance=salt, timeframe='stage2', unit='mmol', destinations=[container,
                                                                                                 new_container]) == expected_salt_amount_stage2, "The reported amount of salt used does not match the expected value."
     # assert residual == 0, "Expected residual volume to be 0 after creating new solution."
 

--- a/tests/test_recipe_volume_used.py
+++ b/tests/test_recipe_volume_used.py
@@ -1,7 +1,7 @@
 import numpy as np
 from pyplate.pyplate import Recipe, Container, Substance
-
 import pytest
+
 
 def test_simple_volume_used(salt_water, water):
     container = Container('container', initial_contents=[(water, '20 mL')])
@@ -12,7 +12,7 @@ def test_simple_volume_used(salt_water, water):
     recipe.bake()
     
     #Assertions
-    assert recipe.volume_used(container, 'all', 'mL') == 100
+    assert recipe.get_substance_used(container, 'all', 'mL') == 100
 
 def test_container_flows(sodium_sulfate, water):
     

--- a/tests/test_volume_used_Plate_transfer.py
+++ b/tests/test_volume_used_Plate_transfer.py
@@ -19,7 +19,7 @@ def test_2(salt, water):
     recipe.transfer(container, plate, quantity='50 uL')
     recipe.transfer(plate, plate2, quantity='10 uL')
     recipe.bake()
-    assert recipe.substance_used(salt, 'all', 'mmol') == '100.0 mmol'
+    assert recipe.get_substance_used(salt, 'all', 'mmol') == '100.0 mmol'
     # 50 umol * 96 = 4.8 mmol
-    assert recipe.substance_used(salt, 'dispensing', 'mmol') == '4.8 mmol'
+    assert recipe.get_substance_used(salt, 'dispensing', 'mmol') == '4.8 mmol'
     # returns 4.8 mmol + 10 umol * 96 = 5.76 mmol


### PR DESCRIPTION
Hello! Hopefully, this is appropriate, but I noticed a few tests were broken.

This PR represents simple API changes that were introduced in f5559c3c77f0994a22b6c1d17c8167b087c4333d. 

Overview of changes:

- `Factor` no longer has the `verifier` init parameter.
- `Experiment` now includes the `verifier` parameter.
- Fixed `map_well` to `map_container`.
- `Experiment` string representation to include `Container`.
- `ExperimentalSpace` has  'factor_rules' as init params.
- Fixed `substance_used` to `get_substanced_used` in Recipe.

Six tests are still failing, but it might be more appropriate that they have their own PRs—they might represent bigger changes.

Let me know if you want me to squash these commits before merging or any other cleanup.

Hopefully, this is helpful - feel free to close out this PR if it isn't! Thanks!