### PR TITLE
Feature: Updating Dependencies for Python 3.12 Compatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy==1.23.5
+numpy>=1.23.5
 pytest>=7.1.2
 pytest-cov>=4.1.0
 pyyaml>=6.0.1
-pandas==1.5.3
-tabulate==0.9.0
+pandas>=1.5.3
+tabulate>=0.9.0


### PR DESCRIPTION
Adjusted requirements.txt to allow for newer versions of NumPy, pandas, and tabulate. The strict version requirements were causing installation/build issues for Python 3.12.

All three Python versions were tested by creating new Conda environments, running `pip install -r requirements.txt`, and ensuring all the unit tests passed.