### PR TITLE
Feature: (Soft) Require Solid Density for Substance.solid()

### DIFF
--- a/examples/Example.py
+++ b/examples/Example.py
@@ -6,7 +6,7 @@ from pyplate import Substance, Container, Plate, Recipe
 
 # define reagents
 print("reagents:")
-sodium_sulfate = Substance.solid("sodium sulfate", mol_weight=142.04)
+sodium_sulfate = Substance.solid("sodium sulfate", mol_weight=142.04, density=2.66)
 triethylamine = Substance.liquid("triethylamine", mol_weight=101.19, density=0.726)
 water_tap = Substance.liquid("tap water", 18.0153, 1)
 water_DI = Substance.liquid("DI water", 18.0153, 1)
@@ -118,14 +118,14 @@ triethylamine_10mM = Container.create_solution(solute=triethylamine, concentrati
                                                solvent=DMSO, total_quantity='10.0 mL')
 print(triethylamine_10mM)
 print("Diluting to 0.005 M")
-result = triethylamine_10mM.dilute(solute=triethylamine, concentration='0.005 M', solvent=DMSO)
+result = triethylamine_10mM.dilute_in_place(solute=triethylamine, concentration='0.005 M', solvent=DMSO)
 print(result)
 print("New concentration:", result.contents[triethylamine]/result.volume)
 
 sodium_sulfate_halfM = Container.create_solution(solute=sodium_sulfate, concentration='0.5 M',
                                                  solvent=water_DI, total_quantity='10.0 mL')
 print(sodium_sulfate_halfM)
-result = sodium_sulfate_halfM.dilute(solute=sodium_sulfate, concentration='0.25 M', solvent=water_DI)
+result = sodium_sulfate_halfM.dilute_in_place(solute=sodium_sulfate, concentration='0.25 M', solvent=water_DI)
 print(result)
 print(result.contents[sodium_sulfate]/result.volume)
 

--- a/examples/Test_Example.py
+++ b/examples/Test_Example.py
@@ -2,15 +2,13 @@ from pyplate import Substance, Container, Recipe, Plate
 
 
 water = Substance.liquid('H2O', mol_weight=18.0153, density=1)
-salt = Substance.solid('NaCl', 58.4428)
+salt = Substance.solid('NaCl', 58.4428, 2.17)
 triethylamine = Substance.liquid("triethylamine", mol_weight=101.19, density=0.726)
 
-recipe = Recipe()
-water_stock = recipe.create_container('water stock', 'inf L', [(water, '1000 mL')])
-salt_source = recipe.create_container('salt source', 'inf L', [(salt, '1000 g')])
-recipe.create_container('halfM salt water', '1 L', ((water, '100 mL'), (salt, '50 mmol')))
-results = recipe.bake()
-salt_water_halfM = results['halfM salt water']
+
+water_stock = Container('water stock', 'inf L', [(water, '1000 mL')])
+salt_source = Container('salt source', 'inf L', [(salt, '1000 g')])
+salt_water_halfM = Container('halfM salt water', '1 L', ((water, '100 mL'), (salt, '50 mmol')))
 
 
 water_stock_2 = Container('water stock', 'inf L', [(water, '1000 mL')])

--- a/pyplate/config.py
+++ b/pyplate/config.py
@@ -39,7 +39,6 @@ class Config:
         assert ('/' in self.concentration_display_unit or self.concentration_display_unit[-1] == 'm' or
                 self.concentration_display_unit[-1] == 'M')
         self.default_solid_density = float(yaml_config['default_solid_density'])
-        self.default_enzyme_density = float(yaml_config['default_enzyme_density'])
         self.default_weight_volume_units = yaml_config['default_weight_volume_units']
 
         self.default_colormap = yaml_config['default_colormap']

--- a/pyplate/pyplate.yaml
+++ b/pyplate/pyplate.yaml
@@ -25,9 +25,9 @@ mass_display_unit: g
 # Default concentration unit for get_concentration()
 concentration_display_unit: M
 
-# density for solids/enzymes in g/mL or U/mL. Can be set to float('inf') to give solids and enzymes zero volume.
+# density for solids in g/mL. 
+# Can be set to float('inf') to give solids and zero volume.
 default_solid_density: 1
-default_enzyme_density: 1
 
 # units for %w/v
 default_weight_volume_units: g/mL

--- a/pyplate/substance.py
+++ b/pyplate/substance.py
@@ -1,6 +1,8 @@
 # Allow typing reference while still building classes
 from __future__ import annotations
 
+import warnings
+
 from pyplate.config import config
 
 class Substance:
@@ -82,19 +84,27 @@ class Substance:
 
     @staticmethod
     def solid(name: str, mol_weight: float, 
-              density: float, molecule=None) -> Substance:
+              density: float = None, molecule=None) -> Substance:
         """
         Creates a solid substance.
 
         Arguments:
             name: Name of substance.
             mol_weight: Molecular weight in g/mol
-            density: Density in g/mL
+            density: Density in g/mL. If not provided, a warning will be raised,
+                     and a default value will be used.
             molecule: (optional) A cctk.Molecule
 
         Returns: A new solid substance with the specified properties.
-
         """
+        if density is None:
+            warning_msg = (
+                f"Density not provided; using default value of {config.default_solid_density} g/mL. "
+                "This may result in unexpected volumes for quantities of this substance and "
+                "solutions containing it."
+            )
+            warnings.warn(warning_msg, stacklevel=2)
+            density = config.default_solid_density
         return Substance(name, Substance.SOLID, mol_weight, density, molecule)
 
 

--- a/pyplate/substance.py
+++ b/pyplate/substance.py
@@ -20,7 +20,8 @@ class Substance:
 
     classes = {SOLID: 'Solids', LIQUID: 'Liquids'}
 
-    def __init__(self, name: str, mol_type: int, molecule=None):
+    def __init__(self, name: str, mol_type: int, 
+                 density:float = None, molecule=None):
         """
         Create a new substance.
 
@@ -42,8 +43,8 @@ class Substance:
 
         self.name = name
         self._type = mol_type
-        self.mol_weight = self.concentration = None
-        self.density = float('inf')
+        self.mol_weight = None
+        self.density = density if density is not None else config.default_solid_density
         self.molecule = molecule
 
     def __repr__(self):
@@ -52,20 +53,24 @@ class Substance:
     def __eq__(self, other):
         if not isinstance(other, Substance):
             return False
-        return self.name == other.name and self._type == other._type and self.mol_weight == other.mol_weight \
-            and self.density == other.density and self.concentration == other.concentration
+        return self.name == other.name and \
+                self._type == other._type and \
+                self.mol_weight == other.mol_weight and \
+                self.density == other.density 
 
     def __hash__(self):
-        return hash((self.name, self._type, self.mol_weight, self.density, self.concentration))
+        return hash((self.name, self._type, self.mol_weight, self.density))
 
     @staticmethod
-    def solid(name: str, mol_weight: float, molecule=None) -> Substance:
+    def solid(name: str, mol_weight: float, 
+              density: float, molecule=None) -> Substance:
         """
         Creates a solid substance.
 
         Arguments:
             name: Name of substance.
             mol_weight: Molecular weight in g/mol
+            density: Density in g/mL
             molecule: (optional) A cctk.Molecule
 
         Returns: New substance.
@@ -75,17 +80,23 @@ class Substance:
             raise TypeError("Name must be a str.")
         if not isinstance(mol_weight, (int, float)):
             raise TypeError("Molecular weight must be a float.")
+        if not isinstance(density, (int, float)):
+            raise TypeError("Density must be a float.")
 
         if not mol_weight > 0:
             raise ValueError("Molecular weight must be positive.")
+        
+        if not density > 0:
+            raise ValueError("Density must be positive.")
 
         substance = Substance(name, Substance.SOLID, molecule)
         substance.mol_weight = mol_weight
-        substance.density = config.default_solid_density
+        substance.density = density
         return substance
 
     @staticmethod
-    def liquid(name: str, mol_weight: float, density: float, molecule=None) -> Substance:
+    def liquid(name: str, mol_weight: float, 
+               density: float, molecule=None) -> Substance:
         """
         Creates a liquid substance.
 
@@ -113,7 +124,6 @@ class Substance:
         substance = Substance(name, Substance.LIQUID, molecule)
         substance.mol_weight = mol_weight  # g / mol
         substance.density = density  # g / mL
-        substance.concentration = density / mol_weight  # mol / mL
         return substance
 
     def is_solid(self) -> bool:

--- a/pyplate/substance.py
+++ b/pyplate/substance.py
@@ -21,13 +21,16 @@ class Substance:
     classes = {SOLID: 'Solids', LIQUID: 'Liquids'}
 
     def __init__(self, name: str, mol_type: int, 
-                 density:float = None, molecule=None):
+                 mol_weight: float, density: float, 
+                 molecule=None):
         """
         Create a new substance.
 
         Arguments:
             name: Name of substance.
             mol_type: Substance.SOLID or Substance.LIQUID.
+            mol_weight: The molecular weight of the substance in g/mol.
+            density: The density of the substance in g/mL.
             molecule: (optional) A cctk.Molecule.
 
         If  cctk.Molecule is provided, molecular weight will automatically populate.
@@ -36,15 +39,31 @@ class Substance:
         """
         if not isinstance(name, str):
             raise TypeError("Name must be a str.")
+        
         if not isinstance(mol_type, int):
             raise TypeError("Type must be an int.")
+        
+        if not isinstance(mol_weight, (int, float)):
+            raise TypeError("Molecular weight must be a float.")
+        if not isinstance(density, (int, float)):
+            raise TypeError("Density must be a float.")
+
+
         if len(name) == 0:
             raise ValueError("Name must not be empty.")
+        if mol_type not in Substance.classes.keys():
+            #TODO: Maybe improve this error message for users
+            raise ValueError("Molecular type unsupported. " + 
+                             f"Type must be one of: {Substance.classes}") 
+        if not mol_weight > 0:
+            raise ValueError("Molecular weight must be positive.")
+        if not density > 0:
+            raise ValueError("Density must be positive.")
 
         self.name = name
         self._type = mol_type
-        self.mol_weight = None
-        self.density = density if density is not None else config.default_solid_density
+        self.mol_weight = mol_weight
+        self.density = density
         self.molecule = molecule
 
     def __repr__(self):
@@ -73,26 +92,11 @@ class Substance:
             density: Density in g/mL
             molecule: (optional) A cctk.Molecule
 
-        Returns: New substance.
+        Returns: A new solid substance with the specified properties.
 
         """
-        if not isinstance(name, str):
-            raise TypeError("Name must be a str.")
-        if not isinstance(mol_weight, (int, float)):
-            raise TypeError("Molecular weight must be a float.")
-        if not isinstance(density, (int, float)):
-            raise TypeError("Density must be a float.")
+        return Substance(name, Substance.SOLID, mol_weight, density, molecule)
 
-        if not mol_weight > 0:
-            raise ValueError("Molecular weight must be positive.")
-        
-        if not density > 0:
-            raise ValueError("Density must be positive.")
-
-        substance = Substance(name, Substance.SOLID, molecule)
-        substance.mol_weight = mol_weight
-        substance.density = density
-        return substance
 
     @staticmethod
     def liquid(name: str, mol_weight: float, 
@@ -106,25 +110,9 @@ class Substance:
             density: Density in g/mL
             molecule: (optional) A cctk.Molecule
 
-        Returns: New substance.
-
+        Returns: A new liquid substance with the specified properties.
         """
-        if not isinstance(name, str):
-            raise TypeError("Name must be a str.")
-        if not isinstance(mol_weight, (int, float)):
-            raise TypeError("Molecular weight must be a float.")
-        if not isinstance(density, (int, float)):
-            raise TypeError("Density must be a float.")
-
-        if not mol_weight > 0:
-            raise ValueError("Molecular weight must be positive.")
-        if not density > 0:
-            raise ValueError("Density must be positive.")
-
-        substance = Substance(name, Substance.LIQUID, molecule)
-        substance.mol_weight = mol_weight  # g / mol
-        substance.density = density  # g / mL
-        return substance
+        return Substance(name, Substance.LIQUID, mol_weight, density, molecule)
 
     def is_solid(self) -> bool:
         """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,7 @@ from pyplate import Substance, Container, Plate
 
 @pytest.fixture
 def salt() -> Substance:
-    return Substance.solid('NaCl', 58.4428)
+    return Substance.solid('NaCl', 58.4428, 2.17)
 
 
 @pytest.fixture
@@ -29,7 +29,7 @@ def dmso() -> Substance:
 
 @pytest.fixture
 def sodium_sulfate() -> Substance:
-    return Substance.solid('Sodium sulfate', 142.04)
+    return Substance.solid('Sodium sulfate', 142.04, 2.66)
 
 
 @pytest.fixture

--- a/tests/test_Container.py
+++ b/tests/test_Container.py
@@ -53,14 +53,14 @@ def test_Container_transfer(water, salt, water_stock, salt_water):
     salt_water_volume = Unit.convert_from_storage(salt_water.volume, 'mL')
     container1, container2 = Container.transfer(salt_water, water_stock, f"{salt_water_volume * 0.1} mL")
     # 10 mL of water and 5 mol of salt should have been transferred
-    assert container1.volume == Unit.convert(water, '90 mL', config.volume_storage_unit) \
-           + Unit.convert(salt, '45 mmol', config.volume_storage_unit)
-    assert container1.contents[water] == Unit.convert(water, '90 mL', config.moles_storage_unit)
-    assert container1.contents[salt] == Unit.convert(salt, '45 mmol', config.moles_storage_unit)
-    assert container2.volume == Unit.convert(water, '20 mL', config.volume_storage_unit) \
-           + Unit.convert(salt, '5 mmol', config.volume_storage_unit)
+    assert container1.volume == pytest.approx(Unit.convert(water, '90 mL', config.volume_storage_unit) \
+           + Unit.convert(salt, '45 mmol', config.volume_storage_unit))
+    assert container1.contents[water] == pytest.approx(Unit.convert(water, '90 mL', config.moles_storage_unit))
+    assert container1.contents[salt] == pytest.approx(Unit.convert(salt, '45 mmol', config.moles_storage_unit))
+    assert container2.volume == pytest.approx(Unit.convert(water, '20 mL', config.volume_storage_unit) \
+           + Unit.convert(salt, '5 mmol', config.volume_storage_unit))
     assert salt in container2.contents and container2.contents[salt] == \
-           Unit.convert(salt, '5 mmol', config.moles_storage_unit)
+           pytest.approx(Unit.convert(salt, '5 mmol', config.moles_storage_unit))
     assert container2.contents[water] == pytest.approx(Unit.convert(water, '20 mL', config.moles_storage_unit))
 
     # Original containers should be unchanged.

--- a/tests/test_Substance.py
+++ b/tests/test_Substance.py
@@ -13,17 +13,27 @@ def test_make_solid():
     """
     # Argument types checked
     with pytest.raises(TypeError, match="Name must be a str"):
-        Substance.solid(1, 1)
+        Substance.solid(1, 1, 1)
     with pytest.raises(ValueError, match="Name must not be empty"):
-        Substance.solid('', 1)
+        Substance.solid('', 1, 1)
     with pytest.raises(TypeError, match="Molecular weight must be a float"):
-        Substance.solid('water', '1')
+        Substance.solid('water', [], 1)
+    with pytest.raises(TypeError, match="Molecular weight must be a float"):
+        Substance.solid('water', '1', 1)
+    with pytest.raises(TypeError, match="Density must be a float"):
+        Substance.solid('water', 18.0153, "")
+    with pytest.raises(TypeError, match="Density must be a float"):
+        Substance.solid('water', 18.0153, "1")
 
     # Arguments are sane
     with pytest.raises(ValueError, match="Molecular weight must be positive"):
-        Substance.solid('water', -1)
+        Substance.solid('water', -1, 1)
     with pytest.raises(ValueError, match="Molecular weight must be positive"):
-        Substance.solid('water', 0)
+        Substance.solid('water', 0, 1)
+    with pytest.raises(ValueError, match="Density must be positive"):
+        Substance.solid('water', 1, -1)
+    with pytest.raises(ValueError, match="Density must be positive"):
+        Substance.solid('water', 1, 0)
 
 
 def test_solid(salt):
@@ -34,6 +44,7 @@ def test_solid(salt):
     """
     assert salt.name == 'NaCl'
     assert salt.mol_weight == 58.4428
+    assert salt.density == 2.17
 
 
 def test_make_liquid():

--- a/tests/test_recipe_get_container_flows.py
+++ b/tests/test_recipe_get_container_flows.py
@@ -36,8 +36,11 @@ def test_container_flows(sodium_sulfate, water):
     recipe.bake()
 
     assert recipe.get_container_flows(container=stock_solution,
-                                      timeframe='all', unit='g') == {"in": 0, "out": 10}
-    assert recipe.get_container_flows(container=dest_container, timeframe='stage 2', unit='mL') == {"out": 9.29,
+                                      timeframe='all', unit='mL') == {"in": 0, "out": 10}
+    # TODO: Remove highly test-specific magic number; compute this from the 
+    # properties of substances involved, and/or change "create_solution" to make
+    # this number easier to determine.
+    assert recipe.get_container_flows(container=dest_container, timeframe='stage 2', unit='mL') == {"out": 9.733,
                                                                                                     "in": 0}
 
 

--- a/tests/test_transfers.py
+++ b/tests/test_transfers.py
@@ -36,12 +36,12 @@ def test_transfer_between_containers(solution1, solution2, water, salt, dmso, so
     assert solution1.volume == Unit.convert_to_storage(solution1_volume, 'mL')
     assert solution2.volume == Unit.convert_to_storage(solution2_volume, 'mL')
     # 10 mL of water and 5 moles of salt should have been transferred
-    assert solution3.get_volume(unit='mL') == solution1_volume * 0.9
-    assert solution4.volume == Unit.convert_to_storage(solution2_volume + solution1_volume*0.1, 'mL')
-    assert solution3.contents[water] == Unit.convert(water, '90 mL', config.moles_storage_unit)
-    assert solution3.contents[salt] == Unit.convert(salt, '45 mmol', config.moles_storage_unit)
+    assert solution3.get_volume(unit='mL') == pytest.approx(solution1_volume * 0.9)
+    assert solution4.volume == pytest.approx(Unit.convert_to_storage(solution2_volume + solution1_volume*0.1, 'mL'))
+    assert solution3.contents[water] == pytest.approx(Unit.convert(water, '90 mL', config.moles_storage_unit))
+    assert solution3.contents[salt] == pytest.approx(Unit.convert(salt, '45 mmol', config.moles_storage_unit))
     assert solution4.contents[water] == pytest.approx(Unit.convert(water, '10 mL', config.moles_storage_unit))
-    assert solution4.contents[salt] == Unit.convert(salt, '5 mmol', config.moles_storage_unit)
+    assert solution4.contents[salt] == pytest.approx(Unit.convert(salt, '5 mmol', config.moles_storage_unit))
 
 
 def test_transfer_to_slice(plate1, solution1, salt):


### PR DESCRIPTION
Various unrealistic behaviors were noticed for solids that resulted from their densities automatically being set to 1. 

A simple example would be adding an arbitrary quantity, say 50 grams, of an arbitrary solid substance, say NaCl, to a container. The container would report a volume of 50 mL, but in reality NaCl has a density of around 2.17 g/mL, so the actual volume taken up by the salt would be ~23 mL.

To address these problems, both the `Substance()` constructor and `Substance.solid()` have been given an additional parameter, density, to allow for this value to be specified for both currently supported phases of matter (solids and liquids). 

However, there are cases where a user may not know the density of a solid, or it may not be required for setting up their experiments (e.g. when the solid is in a very dilute solution, and the concentration in said solution need not be precise). To allow for these cases, `Substance.solid()` can still be called without providing a density. Doing so will trigger a warning for the user to inform them of the risks associated with not providing a density, which they can either choose to ignore or choose to address by providing a density.

As one might expect, the unit test code responsible for creating solids was refactored to provide solid densities. This broke some of the strict equalities present on many of the assert statements, so a number of these were adjusted to include a call to `pytest.approx()`. The two example files were also updated to include solid densities for `Substance.solid()`. 

Additional cleanup changes that were made to `Substance`:

- Unused `concentration` attribute was removed.
- Constructor argument value checking was improved - unsupported molecule types will now trigger a `ValueError`.
- Constructor now requires a molecular weight and density, both of which must be positive (for now, the door for infinite density and molecular weight has been left open, but this may be removed if deemed appropriate).
- Repeated code across `Substance()`, `Substance.solid()`, and `Substance.liquid()` was consolidated (the latter two functions simply call the constructor with the appropriate phase of matter). 

Additional changes that were missed in previous features:
- The two example files contained references to the functions `Recipe.create_container()` and `Container.dilute()`, both of which were removed in [the Container rework feature pull request](https://github.com/ekwan/PyPlate/pull/33). These examples were updated to reflect the current state of the library.
- The default enzyme density parameter was not removed from either the `Config` class or `pyplate.yaml`. The parameter has now been removed from both files.